### PR TITLE
new versions

### DIFF
--- a/modules/gcp/main.tf
+++ b/modules/gcp/main.tf
@@ -1,5 +1,5 @@
 module "enable_apis" {
-  source = "git::https://github.com/terraform-google-modules/terraform-google-project-factory//modules/project_services?ref=v14.4.0"
+  source = "git::https://github.com/terraform-google-modules/terraform-google-project-factory//modules/project_services?ref=v14.5.0"
 
   project_id = var.project.id
 
@@ -29,7 +29,7 @@ module "network" {
 
 
 module "gke" {
-  source                          = "git::https://github.com/terraform-google-modules/terraform-google-kubernetes-engine.git//modules/private-cluster?ref=v29.0.0"
+  source                          = "git::https://github.com/terraform-google-modules/terraform-google-kubernetes-engine.git//modules/private-cluster?ref=v30.2.0"
   for_each                        = var.gke_clusters
   project_id                      = var.project.id
   kubernetes_version              = each.value.kubernetes_version

--- a/modules/gcp/network/main.tf
+++ b/modules/gcp/network/main.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source                  = "git::https://github.com/terraform-google-modules/terraform-google-network//modules/vpc?ref=v8.0.0"
+  source                  = "git::https://github.com/terraform-google-modules/terraform-google-network//modules/vpc?ref=v9.0.0"
   project_id              = var.vpc.project_id
   network_name            = var.vpc.name
   description             = var.vpc.description
@@ -8,7 +8,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source           = "git::https://github.com/terraform-google-modules/terraform-google-network//modules/subnets?ref=v8.0.0"
+  source           = "git::https://github.com/terraform-google-modules/terraform-google-network//modules/subnets?ref=v9.0.0"
   project_id       = module.vpc.project_id
   network_name     = module.vpc.network_name
   subnets          = local.subnets


### PR DESCRIPTION
updated versions to support pers_sparkswarp. it should be remembered that Terraform-google-kubernetes-engine supports dual-stack ip starting from version 30