### PR TITLE
gcp: gcs module

### DIFF
--- a/modules/gcp/gcs/input.tf
+++ b/modules/gcp/gcs/input.tf
@@ -1,0 +1,177 @@
+variable "name" {
+  description = "The name of the bucket."
+  type        = string
+}
+
+variable "location" {
+  description = "The location of the bucket."
+  type        = string
+}
+
+variable "storage_class" {
+  description = "The Storage Class of the new bucket."
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "A set of key/value label pairs to assign to the bucket."
+  type        = map(string)
+  default     = null
+}
+
+
+variable "bucket_policy_only" {
+  description = "Enables Bucket Policy Only access to a bucket."
+  type        = bool
+  default     = false
+}
+
+variable "versioning" {
+  description = "While set to true, versioning is fully enabled for this bucket."
+  type        = bool
+  default     = true
+}
+
+variable "autoclass" {
+  description = "While set to true, autoclass is enabled for this bucket."
+  type        = bool
+  default     = false
+}
+
+variable "force_destroy" {
+  description = "When deleting a bucket, this boolean option will delete all contained objects. If false, Terraform will fail to delete buckets which contain objects."
+  type        = bool
+  default     = false
+}
+
+variable "retention_policy" {
+  description = "Configuration of the bucket's data retention policy for how long objects in the bucket should be retained."
+  type = object(
+    {
+      is_locked        = bool
+      retention_period = number
+    }
+  )
+  default = null
+}
+
+variable "custom_placement_config" {
+  description = "Configuration of the bucket's custom location in a dual-region bucket setup. If the bucket is designated a single or multi-region, the variable are null."
+  type = object(
+    {
+      data_locations = list(string)
+    }
+  )
+  default = null
+}
+
+variable "cors" {
+  description = "Configuration of CORS for bucket with structure as defined in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#cors."
+  type = list(
+    object(
+      {
+        origins = optional(
+          list(string)
+        )
+        methods = optional(
+          list(string)
+        )
+        response_headers = optional(
+          list(string)
+        )
+        max_age_seconds = optional(number)
+      }
+    )
+  )
+  default = []
+}
+
+variable "encryption" {
+  description = "A Cloud KMS key that will be used to encrypt objects inserted into this bucket"
+  type = object(
+    {
+      default_kms_key_name = string
+    }
+  )
+  default = null
+}
+
+variable "lifecycle_rules" {
+  description = "The bucket's Lifecycle Rules configuration."
+  type = list(
+    object(
+      {
+        action = object(
+          {
+            type          = string
+            storage_class = optional(string)
+          }
+        )
+        condition = object(
+          {
+            age            = optional(number)
+            no_age         = optional(bool, false)
+            created_before = optional(string)
+            with_state     = optional(string)
+            matches_storage_class = optional(
+              list(string),
+            )
+            matches_prefix = optional(
+              list(string),
+            )
+            matches_suffix = optional(
+              list(string),
+            )
+            num_newer_versions         = optional(string)
+            custom_time_before         = optional(string)
+            days_since_custom_time     = optional(number)
+            days_since_noncurrent_time = optional(number)
+            noncurrent_time_before     = optional(string)
+          }
+        )
+      }
+    )
+  )
+  default = []
+}
+
+variable "logging" {
+  description = "Bucket logging configuration."
+  type = object(
+    {
+      bucket        = string
+      object_prefix = string
+    }
+  )
+  default = null
+}
+
+variable "website" {
+  type = object(
+    {
+      main_page_suffix = optional(string)
+      not_found_page   = optional(string)
+    }
+  )
+  description = "Website values"
+  default     = null
+}
+
+variable "public_access_prevention" {
+  description = "Prevents public access to a bucket. Acceptable values are inherited or enforced. If inherited, the bucket uses public access prevention, only if the bucket is subject to the public access prevention organization policy constraint."
+  type        = string
+  default     = "inherited"
+}
+
+variable "iam_roles" {
+  description = "Iam roles for the bucket"
+  type = list(
+    object(
+      {
+        role    = string
+        members = list(string)
+      }
+    )
+  )
+}

--- a/modules/gcp/gcs/main.tf
+++ b/modules/gcp/gcs/main.tf
@@ -1,0 +1,100 @@
+resource "google_storage_bucket" "bucket" {
+  name                        = var.name
+  location                    = var.location
+  storage_class               = var.storage_class
+  uniform_bucket_level_access = var.bucket_policy_only
+  labels                      = var.labels
+  force_destroy               = var.force_destroy
+  public_access_prevention    = var.public_access_prevention
+
+  versioning {
+    enabled = var.versioning
+  }
+
+  autoclass {
+    enabled = var.autoclass
+  }
+
+  dynamic "retention_policy" {
+    for_each = var.retention_policy == null ? [] : [var.retention_policy]
+    content {
+      is_locked        = var.retention_policy.is_locked
+      retention_period = var.retention_policy.retention_period
+    }
+  }
+
+  dynamic "encryption" {
+    for_each = var.encryption == null ? [] : [var.encryption]
+    content {
+      default_kms_key_name = var.encryption.default_kms_key_name
+    }
+  }
+
+  dynamic "website" {
+    for_each = var.website == null ? [] : [var.website]
+    content {
+      main_page_suffix = website.value.main_page_suffix
+      not_found_page   = website.value.not_found_page
+    }
+  }
+
+  dynamic "cors" {
+    for_each = var.cors
+    content {
+      origin          = cors.value.origins
+      method          = cors.value.methods
+      response_header = cors.value.response_headers
+      max_age_seconds = cors.value.max_age_seconds
+    }
+  }
+
+  dynamic "custom_placement_config" {
+    for_each = var.custom_placement_config == null ? [] : [var.custom_placement_config]
+    content {
+      data_locations = var.custom_placement_config.data_locations
+    }
+  }
+
+  dynamic "lifecycle_rule" {
+    for_each = var.lifecycle_rules
+    content {
+      action {
+        type          = lifecycle_rule.value.action.type
+        storage_class = lifecycle_rule.value.action.storage_class
+      }
+      condition {
+        age                        = lifecycle_rule.value.condition.age
+        created_before             = lifecycle_rule.value.condition.created_before
+        with_state                 = lifecycle_rule.value.condition.with_state
+        matches_storage_class      = lifecycle_rule.value.condition.matches_storage_class
+        matches_prefix             = lifecycle_rule.value.condition.matches_prefix
+        matches_suffix             = lifecycle_rule.value.condition.matches_suffix
+        num_newer_versions         = lifecycle_rule.value.condition.num_newer_versions
+        custom_time_before         = lifecycle_rule.value.condition.custom_time_before
+        days_since_custom_time     = lifecycle_rule.value.condition.days_since_custom_time
+        days_since_noncurrent_time = lifecycle_rule.value.condition.days_since_noncurrent_time
+        noncurrent_time_before     = lifecycle_rule.value.condition.noncurrent_time_before
+      }
+    }
+  }
+
+  dynamic "logging" {
+    for_each = var.logging == null ? [] : [var.logging]
+    content {
+      log_bucket        = logging.value.bucket
+      log_object_prefix = logging.value.object_prefix
+    }
+  }
+}
+
+
+resource "google_storage_bucket_iam_binding" "bindings" {
+  for_each = {
+    for iam_role_obj in var.iam_roles :
+    iam_role_obj.role => iam_role_obj
+  }
+  bucket = google_storage_bucket.bucket.name
+  role   = each.value.role
+
+  members = each.value.members
+}


### PR DESCRIPTION
own gcs module. What changed
* Copied gcs module from https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/master/modules/simple_bucket/
* Change input variable types from `any` to `object` for
  * website
  * logging
  * lifecycle_rules
  * cors
* Changed `google_storage_bucket_iam_member` to `google_storage_bucket_iam_bindings`
In gcp main.tf 
* added default values for
  * cors
  * lifecycle_rules
  * bucket_policy
  * website
  * logging
* Refactored creators/viewers/admins interface to adjust to new `iam_roles` var