### PR TITLE
Fix subscriptions

### DIFF
--- a/CHANGELOG_GCP.md
+++ b/CHANGELOG_GCP.md
@@ -1,3 +1,8 @@
+# gcp-v1.3.2
+
+fixes:
+* `pubsub`: var.subscriptions is null. (The given "for_each" argument value is unsuitable: the given "for_each" argument value is null. A map, or set of strings is allowed.)
+
 # gcp-v1.3.1
 
 Enhancements:

--- a/modules/gcp/main.tf
+++ b/modules/gcp/main.tf
@@ -422,7 +422,7 @@ module "pubsub" {
   editors                    = try(each.value.editors, [])
   admins                     = try(each.value.admins, [])
   viewers                    = try(each.value.viewers, [])
-  subscriptions              = try(each.value.subscriptions, null)
+  subscriptions              = try(each.value.subscriptions, {})
   depends_on = [
     module.enable_apis,
     module.iam,

--- a/modules/gcp/pubsub/input.tf
+++ b/modules/gcp/pubsub/input.tf
@@ -64,5 +64,5 @@ variable "subscriptions" {
     subscribers                       = optional(list(string), [])
     viewers                           = optional(list(string), [])
   }))
-  default = null
+  default = {}
 }


### PR DESCRIPTION
fixes:
* `pubsub`: var.subscriptions is null. (The given "for_each" argument value is unsuitable: the given "for_each" argument value is null. A map, or set of strings is allowed.)