### PR TITLE
Alert Policy: Fix autoclose, added documentation block  

### DIFF
--- a/CHANGELOG_GCP.md
+++ b/CHANGELOG_GCP.md
@@ -1,4 +1,11 @@
+# gcp-v1.8.1
 
+features:
+* `gcp/monitoring/alert_policy`: added block for documentation about policy
+
+fixes: 
+* `gcp/monitoring/alert_policy`: auto_close param has wrong naming
+  
 # gcp-v1.8.0
 
 features:

--- a/modules/gcp/monitoring/alert_policy/input.tf
+++ b/modules/gcp/monitoring/alert_policy/input.tf
@@ -17,6 +17,16 @@ variable "alert_strategy_auto_close" {
   default = null
 }
 
+variable "documentation" {
+  description = "description about alert policy"
+  type = object({
+    content   = optional(string, null)
+    mime_type = optional(string, "text/markdown")
+    subject   = optional(string, null)
+  })
+  default = null
+}
+
 variable "conditions" {
   description = "value"
   type = list(object({

--- a/modules/gcp/monitoring/alert_policy/input.tf
+++ b/modules/gcp/monitoring/alert_policy/input.tf
@@ -12,7 +12,7 @@ variable "combiner" {
 variable "alert_strategy_auto_close" {
   description = "A list of alert strategies for the alert policy."
   type = object({
-    auto_close = string
+    auto_close = optional(string, null)
   })
   default = null
 }
@@ -34,7 +34,7 @@ variable "conditions" {
         alignment_period     = optional(string, null)
         per_series_aligner   = optional(string, null)
         cross_series_reducer = optional(string, null)
-        group_by_fields      = optional(list(string), [])
+        group_by_fields      = optional(list(string), null)
       }), null)
     }), null)
     condition_promql = optional(object({

--- a/modules/gcp/monitoring/alert_policy/input.tf
+++ b/modules/gcp/monitoring/alert_policy/input.tf
@@ -9,7 +9,7 @@ variable "combiner" {
   default     = "OR"
 }
 
-variable "alert_strategy_auto_close" {
+variable "alert_strategy" {
   description = "A list of alert strategies for the alert policy."
   type = object({
     auto_close = optional(string, null)

--- a/modules/gcp/monitoring/alert_policy/input.tf
+++ b/modules/gcp/monitoring/alert_policy/input.tf
@@ -11,8 +11,10 @@ variable "combiner" {
 
 variable "alert_strategy_auto_close" {
   description = "A list of alert strategies for the alert policy."
-  type        = string
-  default     = null
+  type = object({
+    auto_close = string
+  })
+  default = null
 }
 
 variable "conditions" {

--- a/modules/gcp/monitoring/alert_policy/main.tf
+++ b/modules/gcp/monitoring/alert_policy/main.tf
@@ -12,7 +12,7 @@ resource "google_monitoring_alert_policy" "default" {
   combiner     = var.combiner
 
   dynamic "alert_strategy" {
-    for_each = var.alert_strategy_auto_close != null ? [var.alert_strategy_auto_close] : []
+    for_each = var.alert_strategy != null ? [var.alert_strategy] : []
     content {
       auto_close = alert_strategy.value.auto_close
     }

--- a/modules/gcp/monitoring/alert_policy/main.tf
+++ b/modules/gcp/monitoring/alert_policy/main.tf
@@ -18,6 +18,15 @@ resource "google_monitoring_alert_policy" "default" {
     }
   }
 
+  dynamic "documentation" {
+    for_each = var.documentation != null ? [var.documentation] : []
+    content {
+      content   = documentation.value.content
+      mime_type = documentation.value.mime_type
+      subject   = documentation.value.subject
+    }
+  }
+
   dynamic "conditions" {
     for_each = var.conditions
     content {

--- a/modules/gcp/monitoring/input.tf
+++ b/modules/gcp/monitoring/input.tf
@@ -112,10 +112,12 @@ variable "notification_channels" {
 
 variable "alert_policies" {
   type = list(object({
-    display_name              = string
-    combiner                  = optional(string, "OR")
-    severity                  = optional(string, "WARNING")
-    alert_strategy_auto_close = optional(string, null)
+    display_name = string
+    combiner     = optional(string, "OR")
+    severity     = optional(string, "WARNING")
+    alert_strategy_auto_close = optional(object({
+      auto_close = string
+    }), null)
     conditions = optional(list(object({
       display_name = string
       condition_threshold = optional(object({

--- a/modules/gcp/monitoring/input.tf
+++ b/modules/gcp/monitoring/input.tf
@@ -116,7 +116,7 @@ variable "alert_policies" {
     combiner     = optional(string, "OR")
     severity     = optional(string, "WARNING")
     alert_strategy_auto_close = optional(object({
-      auto_close = string
+      auto_close = optional(string, null)
     }), null)
     conditions = optional(list(object({
       display_name = string

--- a/modules/gcp/monitoring/input.tf
+++ b/modules/gcp/monitoring/input.tf
@@ -118,6 +118,11 @@ variable "alert_policies" {
     alert_strategy_auto_close = optional(object({
       auto_close = optional(string, null)
     }), null)
+    documentation = optional(object({
+      content   = optional(string, null)
+      mime_type = optional(string, "text/markdown")
+      subject   = optional(string, null)
+    }))
     conditions = optional(list(object({
       display_name = string
       condition_threshold = optional(object({

--- a/modules/gcp/monitoring/input.tf
+++ b/modules/gcp/monitoring/input.tf
@@ -133,7 +133,7 @@ variable "alert_policies" {
           alignment_period     = optional(string, null)
           per_series_aligner   = optional(string, null)
           cross_series_reducer = optional(string, null)
-          group_by_fields      = optional(list(string), [])
+          group_by_fields      = optional(list(string), null)
         }), null)
       }), null)
       condition_promql = optional(object({

--- a/modules/gcp/monitoring/input.tf
+++ b/modules/gcp/monitoring/input.tf
@@ -115,7 +115,7 @@ variable "alert_policies" {
     display_name = string
     combiner     = optional(string, "OR")
     severity     = optional(string, "WARNING")
-    alert_strategy_auto_close = optional(object({
+    alert_strategy = optional(object({
       auto_close = optional(string, null)
     }), null)
     documentation = optional(object({

--- a/modules/gcp/monitoring/main.tf
+++ b/modules/gcp/monitoring/main.tf
@@ -32,16 +32,16 @@ module "notification_channels" {
 }
 
 module "alert_policies" {
-  source                    = "./alert_policy"
-  for_each                  = { for alert_policy in var.alert_policies : alert_policy.display_name => alert_policy }
-  display_name              = each.value.display_name
-  alert_strategy_auto_close = each.value.alert_strategy_auto_close
-  documentation             = each.value.documentation
-  combiner                  = each.value.combiner
-  conditions                = each.value.conditions
-  severity                  = each.value.severity
-  user_labels               = each.value.user_labels
-  notification_channels     = each.value.notification_channels
+  source                = "./alert_policy"
+  for_each              = { for alert_policy in var.alert_policies : alert_policy.display_name => alert_policy }
+  display_name          = each.value.display_name
+  alert_strategy        = each.value.alert_strategy
+  documentation         = each.value.documentation
+  combiner              = each.value.combiner
+  conditions            = each.value.conditions
+  severity              = each.value.severity
+  user_labels           = each.value.user_labels
+  notification_channels = each.value.notification_channels
 
   depends_on = [
     module.notification_channels

--- a/modules/gcp/monitoring/main.tf
+++ b/modules/gcp/monitoring/main.tf
@@ -36,6 +36,7 @@ module "alert_policies" {
   for_each                  = { for alert_policy in var.alert_policies : alert_policy.display_name => alert_policy }
   display_name              = each.value.display_name
   alert_strategy_auto_close = each.value.alert_strategy_auto_close
+  documentation             = each.value.documentation
   combiner                  = each.value.combiner
   conditions                = each.value.conditions
   severity                  = each.value.severity


### PR DESCRIPTION
# gcp-v1.8.1

features:
* `gcp/monitoring/alert_policy`: added block for documentation about policy

fixes: 
* `gcp/monitoring/alert_policy`: auto_close param has wrong naming